### PR TITLE
Attaching leading comments fixed

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1734,11 +1734,9 @@
             }
 
             // Eating the stack.
-            if (last) {
-                while (last && last.range[0] >= this.range[0]) {
-                    lastChild = last;
-                    last = bottomRight.pop();
-                }
+            while (last && last.range[0] >= this.range[0]) {
+                lastChild = bottomRight.pop();
+                last = bottomRight[bottomRight.length - 1];
             }
 
             if (lastChild) {

--- a/test/fixtures/comment/migrated_0047.js
+++ b/test/fixtures/comment/migrated_0047.js
@@ -1,0 +1,3 @@
+(/* comment */{
+    p1: null
+})

--- a/test/fixtures/comment/migrated_0047.tree.json
+++ b/test/fixtures/comment/migrated_0047.tree.json
@@ -1,0 +1,73 @@
+{
+    "range": [
+        0,
+        31
+    ],
+    "type": "Program",
+    "body": [
+        {
+            "range": [
+                0,
+                31
+            ],
+            "type": "ExpressionStatement",
+            "expression": {
+                "range": [
+                    14,
+                    30
+                ],
+                "type": "ObjectExpression",
+                "properties": [
+                    {
+                        "range": [
+                            20,
+                            28
+                        ],
+                        "type": "Property",
+                        "key": {
+                            "range": [
+                                20,
+                                22
+                            ],
+                            "type": "Identifier",
+                            "name": "p1"
+                        },
+                        "computed": false,
+                        "value": {
+                            "range": [
+                                24,
+                                28
+                            ],
+                            "type": "Literal",
+                            "value": null,
+                            "raw": "null"
+                        },
+                        "kind": "init",
+                        "method": false,
+                        "shorthand": false
+                    }
+                ],
+                "leadingComments": [
+                    {
+                        "type": "Block",
+                        "value": " comment ",
+                        "range": [
+                            1,
+                            14
+                        ]
+                    }
+                ]
+            }
+        }
+    ],
+    "comments": [
+        {
+            "type": "Block",
+            "value": " comment ",
+            "range": [
+                1,
+                14
+            ]
+        }
+    ]
+}

--- a/test/fixtures/comment/migrated_0048.js
+++ b/test/fixtures/comment/migrated_0048.js
@@ -1,0 +1,4 @@
+(/* comment */{
+    p1: null,
+    p2: null
+})

--- a/test/fixtures/comment/migrated_0048.tree.json
+++ b/test/fixtures/comment/migrated_0048.tree.json
@@ -1,0 +1,101 @@
+{
+    "range": [
+        0,
+        45
+    ],
+    "type": "Program",
+    "body": [
+        {
+            "range": [
+                0,
+                45
+            ],
+            "type": "ExpressionStatement",
+            "expression": {
+                "range": [
+                    14,
+                    44
+                ],
+                "type": "ObjectExpression",
+                "properties": [
+                    {
+                        "range": [
+                            20,
+                            28
+                        ],
+                        "type": "Property",
+                        "key": {
+                            "range": [
+                                20,
+                                22
+                            ],
+                            "type": "Identifier",
+                            "name": "p1"
+                        },
+                        "computed": false,
+                        "value": {
+                            "range": [
+                                24,
+                                28
+                            ],
+                            "type": "Literal",
+                            "value": null,
+                            "raw": "null"
+                        },
+                        "kind": "init",
+                        "method": false,
+                        "shorthand": false
+                    },
+                    {
+                        "range": [
+                            34,
+                            42
+                        ],
+                        "type": "Property",
+                        "key": {
+                            "range": [
+                                34,
+                                36
+                            ],
+                            "type": "Identifier",
+                            "name": "p2"
+                        },
+                        "computed": false,
+                        "value": {
+                            "range": [
+                                38,
+                                42
+                            ],
+                            "type": "Literal",
+                            "value": null,
+                            "raw": "null"
+                        },
+                        "kind": "init",
+                        "method": false,
+                        "shorthand": false
+                    }
+                ],
+                "leadingComments": [
+                    {
+                        "type": "Block",
+                        "value": " comment ",
+                        "range": [
+                            1,
+                            14
+                        ]
+                    }
+                ]
+            }
+        }
+    ],
+    "comments": [
+        {
+            "type": "Block",
+            "value": " comment ",
+            "range": [
+                1,
+                14
+            ]
+        }
+    ]
+}

--- a/test/fixtures/comment/migrated_0049.js
+++ b/test/fixtures/comment/migrated_0049.js
@@ -1,0 +1,4 @@
+/**
+ * @type {number}
+ */
+var a = 5;

--- a/test/fixtures/comment/migrated_0049.tree.json
+++ b/test/fixtures/comment/migrated_0049.tree.json
@@ -1,0 +1,63 @@
+{
+    "range": [
+        26,
+        36
+    ],
+    "type": "Program",
+    "body": [
+        {
+            "range": [
+                26,
+                36
+            ],
+            "type": "VariableDeclaration",
+            "declarations": [
+                {
+                    "range": [
+                        30,
+                        35
+                    ],
+                    "type": "VariableDeclarator",
+                    "id": {
+                        "range": [
+                            30,
+                            31
+                        ],
+                        "type": "Identifier",
+                        "name": "a"
+                    },
+                    "init": {
+                        "range": [
+                            34,
+                            35
+                        ],
+                        "type": "Literal",
+                        "value": 5,
+                        "raw": "5"
+                    }
+                }
+            ],
+            "kind": "var",
+            "leadingComments": [
+                {
+                    "type": "Block",
+                    "value": "*\n * @type {number}\n ",
+                    "range": [
+                        0,
+                        25
+                    ]
+                }
+            ]
+        }
+    ],
+    "comments": [
+        {
+            "type": "Block",
+            "value": "*\n * @type {number}\n ",
+            "range": [
+                0,
+                25
+            ]
+        }
+    ]
+}

--- a/test/fixtures/comment/migrated_0050.js
+++ b/test/fixtures/comment/migrated_0050.js
@@ -1,0 +1,8 @@
+/**
+ * @type {number}
+ */
+var a = 5,
+    /**
+     * @type {number}
+     */
+    b = 6;

--- a/test/fixtures/comment/migrated_0050.tree.json
+++ b/test/fixtures/comment/migrated_0050.tree.json
@@ -1,0 +1,105 @@
+{
+    "range": [
+        26,
+        85
+    ],
+    "type": "Program",
+    "body": [
+        {
+            "range": [
+                26,
+                85
+            ],
+            "type": "VariableDeclaration",
+            "declarations": [
+                {
+                    "range": [
+                        30,
+                        35
+                    ],
+                    "type": "VariableDeclarator",
+                    "id": {
+                        "range": [
+                            30,
+                            31
+                        ],
+                        "type": "Identifier",
+                        "name": "a"
+                    },
+                    "init": {
+                        "range": [
+                            34,
+                            35
+                        ],
+                        "type": "Literal",
+                        "value": 5,
+                        "raw": "5"
+                    }
+                },
+                {
+                    "range": [
+                        79,
+                        84
+                    ],
+                    "type": "VariableDeclarator",
+                    "id": {
+                        "range": [
+                            79,
+                            80
+                        ],
+                        "type": "Identifier",
+                        "name": "b"
+                    },
+                    "init": {
+                        "range": [
+                            83,
+                            84
+                        ],
+                        "type": "Literal",
+                        "value": 6,
+                        "raw": "6"
+                    },
+                    "leadingComments": [
+                        {
+                            "type": "Block",
+                            "value": "*\n     * @type {number}\n     ",
+                            "range": [
+                                41,
+                                74
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "kind": "var",
+            "leadingComments": [
+                {
+                    "type": "Block",
+                    "value": "*\n * @type {number}\n ",
+                    "range": [
+                        0,
+                        25
+                    ]
+                }
+            ]
+        }
+    ],
+    "comments": [
+        {
+            "type": "Block",
+            "value": "*\n * @type {number}\n ",
+            "range": [
+                0,
+                25
+            ]
+        },
+        {
+            "type": "Block",
+            "value": "*\n     * @type {number}\n     ",
+            "range": [
+                41,
+                74
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
pop call is moved because it affects comment which is before current node and there is redundant iteration with the same last node

Closes gh-1175
